### PR TITLE
Add image uploading functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Security
+environment.prod.ts
+
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,6 +7,7 @@ import { ForgetPasswordPageComponent } from './components/views/forget-password-
 import { DoesNotExistPageComponent } from './components/views/does-not-exist-page/does-not-exist-page.component';
 import { DashboardComponent } from './components/views/dashboard/dashboard.component';
 import { OrganizationDashboardComponent } from './components/views/organization-dashboard/organization-dashboard.component';
+import { UploadFileComponent } from './components/views/upload-file/upload-file.component';
 
 import { AuthGuard } from './services/auth/auth.guard';
 import { InventoryPanelComponent } from './components/views/inventory-panel/inventory-panel.component';
@@ -84,6 +85,12 @@ const routes: Routes = [
     {
         path: 'organization/transaction/items/add',
         component: ItemsListingPageComponent,
+        pathMatch: 'full',
+        canActivate: [AuthVerifyGuard]
+    },
+    {
+        path: 'upload',
+        component: UploadFileComponent,
         pathMatch: 'full',
         canActivate: [AuthVerifyGuard]
     },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,6 +6,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { AngularFirestoreModule } from '@angular/fire/firestore';
 import { AngularFireAuthModule } from '@angular/fire/auth';
 import { AngularFireModule } from '@angular/fire';
+import { AngularFireStorageModule } from '@angular/fire/storage';
 import { environment } from 'src/environments/environment';
 
 import { AppComponent } from './app.component';
@@ -44,6 +45,7 @@ import { AccountSettingPageComponent } from './components/views/account-setting-
 import { ProfileSummaryPaneComponent } from './components/views/account-setting-page/profile-summary-pane/profile-summary-pane.component';
 import { ProfileDetailPaneComponent } from './components/views/account-setting-page/profile-detail-pane/profile-detail-pane.component';
 import { CredentialPaneComponent } from './components/views/account-setting-page/credential-pane/credential-pane.component';
+import { UploadFileComponent } from './components/views/upload-file/upload-file.component';
 
 @NgModule({
     declarations: [
@@ -75,6 +77,7 @@ import { CredentialPaneComponent } from './components/views/account-setting-page
         ProfileSummaryPaneComponent,
         ProfileDetailPaneComponent,
         CredentialPaneComponent,
+        UploadFileComponent
     ],
     imports: [
         BrowserModule,
@@ -83,6 +86,7 @@ import { CredentialPaneComponent } from './components/views/account-setting-page
         HttpClientModule,
         AngularFireModule.initializeApp(environment.firebase),
         AngularFirestoreModule,
+        AngularFireStorageModule,
         AngularFireAuthModule
     ],
     providers: [

--- a/src/app/components/views/upload-file/upload-file.component.html
+++ b/src/app/components/views/upload-file/upload-file.component.html
@@ -1,0 +1,5 @@
+<input type="file" (change)="uploadFile($event)" />
+
+<div>{{ uploadPercent | async }}</div>
+
+<a [href]="downloadURL | async">{{ downloadURL | async }}</a>

--- a/src/app/components/views/upload-file/upload-file.component.spec.ts
+++ b/src/app/components/views/upload-file/upload-file.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UploadFileComponent } from './upload-file.component';
+
+describe('UploadFileComponent', () => {
+  let component: UploadFileComponent;
+  let fixture: ComponentFixture<UploadFileComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ UploadFileComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UploadFileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/views/upload-file/upload-file.component.ts
+++ b/src/app/components/views/upload-file/upload-file.component.ts
@@ -1,0 +1,38 @@
+// https://github.com/angular/angularfire/blob/master/docs/storage/storage.md
+
+import { Component, OnInit } from '@angular/core';
+import { AngularFireStorage } from '@angular/fire/storage';
+import { Observable } from 'rxjs';
+import { finalize, tap } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-upload-file',
+  templateUrl: './upload-file.component.html',
+  styleUrls: ['./upload-file.component.scss']
+})
+export class UploadFileComponent implements OnInit {
+
+  uploadPercent: Observable<number>;
+  downloadURL: Observable<string>;
+
+  ngOnInit() {
+  }
+
+  constructor(private storage: AngularFireStorage) {}
+
+  uploadFile(event) {
+    const file = event.target.files[0];
+    const filePath = `images/${Date.now()}_${file.name}`;
+    const fileRef = this.storage.ref(filePath);
+    const task = this.storage.upload(filePath, file);
+
+    this.uploadPercent = task.percentageChanges();
+
+    task
+    .snapshotChanges()
+    .pipe(
+      finalize(() => this.downloadURL = fileRef.getDownloadURL())
+    )
+    .subscribe()
+  }
+}


### PR DESCRIPTION
Resolves SenecaCollegeBTSProjects/Group_17#27: introduces minimal image uploading functionality.

This functionality has been added to an `/upload` frontend route for demonstrative purposes.

All images are currently uploaded to an [`images/` Firebase Cloud Storage folder](https://console.firebase.google.com/project/inventurbo-f0eca/storage/inventurbo-f0eca.appspot.com/files~2Fimages).

@VictorHadziristic please feel welcome to use this to help implement avatar uploading!

* * * 

![uploaddemo](https://user-images.githubusercontent.com/13500769/73238100-b442cb00-4165-11ea-81de-b6c64eaf7789.gif)