### PR TITLE
Implement CRUD ProductStock price, hide ProductStock

### DIFF
--- a/src/app/components/views/add-product-stock-page/add-existing-product-pane/add-existing-product-pane.component.html
+++ b/src/app/components/views/add-product-stock-page/add-existing-product-pane/add-existing-product-pane.component.html
@@ -14,7 +14,8 @@
         <div class="search-result pre-scrollable">
             <ng-container *ngFor="let item of productItems">
                 <app-product-item-card
-                    [hidden]="!item.filtered"
+                    [filtered]="!item.filtered"
+                    [hidden]="item.hidden"
                     [product]="item.product"
                     [existed]="item.existed"
                     [selected]="item.selected"

--- a/src/app/components/views/add-product-stock-page/add-existing-product-pane/add-existing-product-pane.component.ts
+++ b/src/app/components/views/add-product-stock-page/add-existing-product-pane/add-existing-product-pane.component.ts
@@ -14,6 +14,7 @@ class ProductItem {
     }
 
     existed = false;
+    hidden = false;
     selected = false;
     filtered = true;
     product: Product;
@@ -52,9 +53,14 @@ export class AddExistingProductPaneComponent implements OnInit {
             })
         ).subscribe(invItems => {
             this.productItems.forEach(prodItem => {
-                if (invItems.some(invItem => invItem.pid === prodItem.product.pid)) {
-                    prodItem.existed = true;
-                }
+                invItems.forEach(invItem => {
+                    if (invItem.pid === prodItem.product.pid) {
+                        prodItem.existed = true;
+                        if (invItem.hidden) {
+                            prodItem.hidden = true;
+                        }
+                    }
+                })
             });
         });
     }

--- a/src/app/components/views/add-product-stock-page/add-existing-product-pane/product-item-card/product-item-card.component.html
+++ b/src/app/components/views/add-product-stock-page/add-existing-product-pane/product-item-card/product-item-card.component.html
@@ -1,4 +1,4 @@
-<div class="product-card">
+<div *ngIf="!filtered" class="product-card">
     <div class="product-photo-wrapper">
         <img class="product-photo" [src]="product.photoURL" [alt]="product.name" onerror="this.src='assets/image-notfound.png';" />        />
     </div>
@@ -6,7 +6,10 @@
         <span class="product-name">{{ product.name }}</span>
     </div>
     <div *ngIf="existed" class="existed-overlay">
-        <div class="existed-overlay-content">This item is already in your inventory</div>
+        <div class="existed-overlay-content">
+            <span *ngIf="!hidden; else hiddenItem">This item is already in your inventory</span>
+            <ng-template #hiddenItem>This item has been discontinued.</ng-template>
+        </div>
     </div>
     <div *ngIf="selected" class="selected-overlay">
         <div class="selected-overlay-content">Selected</div>

--- a/src/app/components/views/add-product-stock-page/add-existing-product-pane/product-item-card/product-item-card.component.ts
+++ b/src/app/components/views/add-product-stock-page/add-existing-product-pane/product-item-card/product-item-card.component.ts
@@ -14,6 +14,12 @@ export class ProductItemCardComponent implements OnInit {
     public existed: boolean;
 
     @Input()
+    public filtered: boolean;
+
+    @Input()
+    public hidden: boolean;
+
+    @Input()
     public selected: boolean;
 
     constructor() {}

--- a/src/app/components/views/add-product-stock-page/create-new-product-pane/create-new-product-pane.component.html
+++ b/src/app/components/views/add-product-stock-page/create-new-product-pane/create-new-product-pane.component.html
@@ -33,6 +33,9 @@
                 <div class="form-group">
                     <textarea formControlName="description" class="form-control description" placeholder="Description"></textarea>
                 </div>
+                <div class="form-group">
+                    <input type="number" formControlName="unit_price" class="form-control unit_price py-12" placeholder="Price (optional)" value="0"/>
+                </div>
             </div>
             <div class="col-md-6">
                 <div class="preview-area">

--- a/src/app/components/views/add-product-stock-page/create-new-product-pane/create-new-product-pane.component.scss
+++ b/src/app/components/views/add-product-stock-page/create-new-product-pane/create-new-product-pane.component.scss
@@ -21,7 +21,7 @@
 // }
 
 textarea.description {
-    height: 14em;
+    height: 11em;
 }
 
 .preview-area {

--- a/src/app/components/views/add-product-stock-page/create-new-product-pane/create-new-product-pane.component.ts
+++ b/src/app/components/views/add-product-stock-page/create-new-product-pane/create-new-product-pane.component.ts
@@ -39,7 +39,8 @@ export class CreateNewProductPaneComponent implements OnInit {
         this.addForm = this.fb.group({
             name: ['', Validators.required],
             description: ['', Validators.required],
-            image: ['', Validators.required]
+            image: ['', Validators.required],
+            unit_price: ['']
         });
     }
 
@@ -58,8 +59,8 @@ export class CreateNewProductPaneComponent implements OnInit {
         let newProduct;
         this.fs.uploadFile(file, '/images/products/').pipe(
             flatMap(url => {
-                const { name, description } = this.addForm.value;
-                newProduct = { name, description, photoURL: url};
+                const { name, description, unit_price } = this.addForm.value;
+                newProduct = { name, description, unit_price, photoURL: url};
                 this.submitBtn.message = 'Creating new product...';
                 return this.prodService.addNewProduct(newProduct);
             }),

--- a/src/app/components/views/inventory-detail-overlay/inventory-detail-overlay.component.html
+++ b/src/app/components/views/inventory-detail-overlay/inventory-detail-overlay.component.html
@@ -4,7 +4,13 @@
 
   <div class="card-body no-padding">
     <h5 class="card-title">{{item.name}}</h5>
-    <h6 class="card-subtitle">Qty: <span class="important-color">{{item.quantity}}</span></h6>
+    <h6 class="card-subtitle">
+        Price:
+            <span class="important-color" *ngIf="item.unit_price; else noPrice">{{item.unit_price | currency}}</span>
+            <ng-template #noPrice class="quantity-number">—</ng-template>
+            <br/>
+        Qty: <span class="important-color">{{item.quantity}}</span>
+    </h6>
     <p class="card-text">{{item.description}}</p>
   </div>
 </div>

--- a/src/app/components/views/inventory-panel/inventory-panel.component.ts
+++ b/src/app/components/views/inventory-panel/inventory-panel.component.ts
@@ -31,8 +31,8 @@ export class InventoryPanelComponent implements OnInit {
         });
         const thisorg = this.userOrg.getCurrentOrganization();
         this.prodStock.getAllOrganizationProductStock(thisorg.oid).subscribe(prod => {
-            this.products = prod;
-            this.filteredProducts = prod;
+            this.products = prod.filter(p => !p.hidden);
+            this.filteredProducts = prod.filter(p => !p.hidden);
         });
     }
 
@@ -46,6 +46,7 @@ export class InventoryPanelComponent implements OnInit {
         } else {
             this.filteredProducts = this.products;
         }
+        this.filteredProducts = this.filteredProducts.filter(prod => !prod.hidden);
     }
 
     ngOnInit() {

--- a/src/app/components/views/location-management-page/location-list-pane/location-list-item/location-list-item.component.ts
+++ b/src/app/components/views/location-management-page/location-list-pane/location-list-item/location-list-item.component.ts
@@ -28,7 +28,9 @@ export class LocationListItemComponent implements OnInit {
 
     onDeleteClick(event: Event) {
         event.stopPropagation();
-        this.deleteButtonClick.emit(this.location);
+        if (confirm(`Are you sure you want to remove ${this.location.name} location?`)) {
+            this.deleteButtonClick.emit(this.location);
+        }
     }
 
     constructor() {}

--- a/src/app/components/views/organization-dashboard/organization-dashboard.component.ts
+++ b/src/app/components/views/organization-dashboard/organization-dashboard.component.ts
@@ -145,7 +145,7 @@ export class OrganizationDashboardComponent implements OnInit, AfterContentCheck
             transactions.forEach(transaction => {
                 const timestamp = Date.parse(transaction.stringTime);
                 const transactionDate = !isNaN(timestamp) ? new Date(timestamp) : new Date();
-                const transactionType = transaction.oid_dest !== this.org.oid ? 'Incoming' : 'Outgoing';
+                const transactionType = transaction.oid_dest === this.org.oid ? 'Incoming' : 'Outgoing';
                 this.transactions.push({timeDate: transactionDate, transactionType, ...transaction});
             });
             this.lastTransactionTime = this.transactions.length > 0 ?

--- a/src/app/components/views/product-detail-page/product-detail-pane/product-detail-pane.component.html
+++ b/src/app/components/views/product-detail-page/product-detail-pane/product-detail-pane.component.html
@@ -4,10 +4,23 @@
     </div>
     <div class="pane-body">
         <h2 class="product-title">{{ product.name }}</h2>
-        <h3 class="product-quantity">Quantity: <span class="quantity-number">{{ product.total_quantity }}</span></h3>
-        <p class="product-desc">Desription: {{ product.description }}</p>
+        <h3 class="product-quantity">
+            Quantity: <span class="quantity-number">{{ product.total_quantity }}</span>
+        </h3>
+        <h3 class="product-price">
+            Price:
+            <span class="quantity-number">
+                $<input class="price-number" step="0.25" type="number" [(ngModel)]="product.unit_price" (change)="toggleSavePriceButton(true)"/>&nbsp;
+                <i *ngIf="displaySavePriceButton" (click)="savePrice()" class="fa fa-save save-btn"></i>
+            </span>
+            <span class="price-saved-message">{{ priceSavedMessage }}</span>
+        </h3>
+        <p class="product-desc">Description: {{ product.description }}</p>
     </div>
-    <a routerLink="/notfound" class="edit-btn">
-        <app-font-awesome-icon-wrapper faClass="fas fa-edit"></app-font-awesome-icon-wrapper>
-    </a>
+    <app-font-awesome-icon-wrapper
+        class="edit-btn"
+        (click)="removeProductStock()"
+        faClass="fas fa-trash-alt"
+        hoverable
+    ></app-font-awesome-icon-wrapper>
 </div>

--- a/src/app/components/views/product-detail-page/product-detail-pane/product-detail-pane.component.scss
+++ b/src/app/components/views/product-detail-page/product-detail-pane/product-detail-pane.component.scss
@@ -27,13 +27,20 @@
     margin-bottom: 0;
 }
 
-.product-quantity {
+.product-quantity, .product-price {
     font-size: 2em;
 }
 
-.quantity-number {
+.quantity-number, .price-number {
     color: #bf202f;
     font-weight: bold;
+    width: 3em !important;
+}
+
+.price-number {
+    border: 1px dashed lightgray !important;
+    padding: 1px;
+    width: 35%;
 }
 
 .product-desc {
@@ -44,5 +51,16 @@
 .edit-btn {
     float: right;
     margin-top: -0.5em;
-    margin-right: -1em;
+    margin-right: -0.5em;
+}
+
+.save-btn {
+    cursor: pointer;
+}
+
+.price-saved-message {
+    font-size: 0.5em;
+    font-style: italic;
+    vertical-align: middle;
+    color: green;
 }

--- a/src/app/components/views/product-detail-page/product-detail-pane/product-detail-pane.component.ts
+++ b/src/app/components/views/product-detail-page/product-detail-pane/product-detail-pane.component.ts
@@ -1,5 +1,8 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { ProductStock } from 'src/app/services/product/product-stock.model';
+import { Router } from '@angular/router';
+import { ProductStockService } from 'src/app/services/product/product-stock.service';
+import { UserOrganizationService } from 'src/app/services/organization/user-organization.service';
 
 @Component({
     selector: 'app-product-detail-pane',
@@ -10,7 +13,49 @@ export class ProductDetailPaneComponent implements OnInit {
     @Input()
     public product: ProductStock;
 
-    constructor() {}
+    public orgId;
 
-    ngOnInit() {}
+    private originalPrice: number;
+    public priceSavedMessage = '';
+    public displaySavePriceButton = false;
+
+    constructor(
+        private router: Router,
+        public orgService: UserOrganizationService,
+        private psService: ProductStockService,
+    ) {
+        this.orgId = this.orgService.getCurrentOrganization().oid;
+    }
+
+    ngOnInit() {
+        this.originalPrice = this.product.unit_price;
+    }
+
+    removeProductStock() {
+        if (confirm('Are you sure you want to remove this product from your inventory?')) {
+            // this.psService.removeProductStock(this.orgService.getCurrentOrganization().oid, this.product.pid)
+            this.psService.hideProductStock(this.orgId, this.product.pid)
+            .subscribe(() => {
+                this.router.navigate(['/organization/inventory']);
+            });
+        }
+    }
+
+    toggleSavePriceButton(value: boolean) {
+        this.priceSavedMessage = '';
+        if (this.product.unit_price === this.originalPrice) {
+            this.displaySavePriceButton = false;
+        } else {
+            this.displaySavePriceButton = value;
+        }
+    }
+
+    savePrice() {
+        this.toggleSavePriceButton(false);
+        this.originalPrice = this.product.unit_price;
+        this.priceSavedMessage = 'Updating price...';
+        this.psService.updateProductStockPrice(this.orgId, this.product.pid, this.product.unit_price).subscribe(_ => {
+            this.priceSavedMessage = 'New price saved!';
+        });
+    }
 }

--- a/src/app/services/product/product-stock.model.ts
+++ b/src/app/services/product/product-stock.model.ts
@@ -12,5 +12,7 @@ export class ProductStock {
     description: string;
     photoURL?: string;
     total_quantity: number;
+    unit_price: number;
     inventoryByLocation?: LocationInventory[];
+    hidden: boolean = false;
 }

--- a/src/app/services/product/product-stock.service.ts
+++ b/src/app/services/product/product-stock.service.ts
@@ -4,7 +4,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { environment as env } from 'src/environments/environment';
 import { catchError } from 'rxjs/operators';
 import { Router } from '@angular/router';
-import { LocationInventory } from './product-stock.model';
+import { LocationInventory, ProductStock } from './product-stock.model';
 
 @Injectable({
     providedIn: 'root'
@@ -55,4 +55,27 @@ export class ProductStockService {
             this.httpOptions
         );
     }
+
+    removeProductStock(oid: string, pid: string): Observable<any> {
+        return this.http.delete<any>(
+            `${env.api}${env.routes.removeProductStock(oid, pid)}`,
+            this.httpOptions
+        );
+    }
+
+    hideProductStock(oid: string, pid: string): Observable<any> {
+        return this.http.put<any>(
+            `${env.api}${env.routes.hideProductStock(oid, pid)}`,
+            this.httpOptions
+        );
+    }
+
+    updateProductStockPrice(oid: string, pid: string, newPrice: number): Observable<any> {
+        return this.http.put<any>(
+            `${env.api}${env.routes.updateProductStockPrice(oid, pid)}`,
+            { unit_price: newPrice },
+            this.httpOptions
+        );
+    }
+
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -26,14 +26,20 @@ export const environment = {
         createProduct: `/product/create`,
 
         getUserOrganizations(uid) { return `/profile/${uid}/organization`; },
+
         getOrganizationProductStocks(oid) { return `/organization/${oid}/product`; },
         getOneProductStock(oid, pid) { return `/organization/${oid}/product/${pid}`; },
         addOneProductStock(oid) { return `/organization/${oid}/product/add/`; },
         updateOneProductStock(oid, pid) { return `/organization/${oid}/product/update/${pid}`; },
+        updateProductStockPrice(oid, pid) { return `/organization/${oid}/product/update/${pid}/price`; },
+        removeProductStock(oid, pid) { return `/organization/${oid}/product/remove/${pid}`; },
+        hideProductStock(oid, pid) { return `/organization/${oid}/product/hide/${pid}`; },
+
         getOrganizationLocations(oid) { return `/organization/${oid}/location`; },
         createOrganizationLocation(oid) { return `/organization/${oid}/location/create`; },
         updateOrganizationLocation(oid, locid) { return `/organization/${oid}/location/update/${locid}`; },
         deleteOrganizationLocation(oid, locid) { return `/organization/${oid}/location/delete/${locid}`; },
+
         getOrganizationTransactions(oid) { return `/organization/${oid}/transaction`; },
         getOneTransaction(tid) { return `/transaction/${tid}`; },
         addSimpleTransaction: `/transaction/create`,


### PR DESCRIPTION
Frontend changes for SenecaCollegeBTSProjects/Group_17#38

- [x] Updated Transaction logic to ensure that item prices within `Requested` Transactions are not affected by future updates to ProductStock price:
![image](https://user-images.githubusercontent.com/13500769/77240874-79876d00-6bc1-11ea-862a-e668ad966b0b.png)
   - [x] I added (what I believe to be) the required backend logic hinted at in the screenshot above: https://github.com/vitokhangnguyen/InvenTurbo-backend/pull/12/commits/2f4340b04474b42e0e5e8a25c98636a6adf543c6
   - [x] Made changes to ensure that price information is being fetched from `TransactionItem` documents (instead of `ProductStock` documents): https://github.com/vitokhangnguyen/InvenTurbo-backend/pull/12/commits/10551fbd0794ac3cbffd54ab0105cb96f61e28a9